### PR TITLE
#96-repair gTests packages

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -13,7 +13,7 @@ Debug
 
 #---  Google Tests  ---#
 packages
-packages.*
+#packages.*
 
 #---  External Documentation  ---#
 docs

--- a/lib/gTests/packages.config
+++ b/lib/gTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.7" targetFramework="native" />
+</packages>


### PR DESCRIPTION
Finally removed from .`gitignore`.